### PR TITLE
Smooth garden color transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,25 @@
   <title>spores.garden</title>
   <link rel="stylesheet" href="/src/themes/base.css">
   <script>
+    // Restore previous theme colors immediately to prevent white flash on navigation.
+    // This runs synchronously before first paint, enabling smooth color transitions
+    // between gardens without showing the default white background.
+    (function () {
+      try {
+        var saved = sessionStorage.getItem('spores.lastTheme');
+        if (saved) {
+          var theme = JSON.parse(saved);
+          var root = document.documentElement;
+          if (theme.background) root.style.setProperty('--color-background', theme.background);
+          if (theme.text) root.style.setProperty('--color-text', theme.text);
+          if (theme.muted) root.style.setProperty('--color-text-muted', theme.muted);
+        }
+      } catch (e) {
+        // Ignore parse errors or storage access issues
+      }
+    })();
+  </script>
+  <script>
     // GitHub Pages SPA redirect handler
     // Restore the URL from sessionStorage if we were redirected from 404.html
     (function () {

--- a/src/components/site-app.ts
+++ b/src/components/site-app.ts
@@ -56,11 +56,20 @@ class SiteApp extends HTMLElement {
 
   async connectedCallback() {
     // Initial loading state
+    // Note: Previous theme colors are restored via inline script in index.html
+    // to prevent white flash before first paint
     this.innerHTML = `<div class="loading">${this.renderer.getLoadingMessage()}</div>`;
 
     try {
       // Initialize config
       const config = await initConfig();
+
+      // Apply theme immediately after config loads (before auth) for faster transition
+      await applyTheme(config.theme);
+      this.isThemeReady = true;
+
+      // Add theme-ready class for smooth content fade-in
+      this.classList.add('theme-ready');
 
       // Initialize Auth (OAuth, Listeners)
       await this.auth.init();
@@ -87,13 +96,6 @@ class SiteApp extends HTMLElement {
       window.addEventListener('share-to-bluesky', () => {
         this.interactions.shareToBluesky();
       });
-
-      // Apply theme and wait for it to be fully applied before rendering
-      await applyTheme(config.theme);
-      this.isThemeReady = true;
-
-      // Add theme-ready class for smooth content fade-in
-      this.classList.add('theme-ready');
 
       // Render only after theme is ready
       await this.renderer.render();

--- a/src/themes/base.css
+++ b/src/themes/base.css
@@ -96,6 +96,8 @@ body {
   line-height: 1.5;
   color: var(--color-text);
   background-color: var(--color-background);
+  /* Smooth color transitions when navigating between gardens */
+  transition: background-color 0.25s ease, color 0.25s ease;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -1379,6 +1381,7 @@ site-app.theme-ready .header {
   padding: var(--spacing-xl);
   color: var(--color-text-muted);
   font-weight: 600;
+  font-size: var(--font-size-xl);
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }


### PR DESCRIPTION
- **Problem:** white flash when switching gardens; loading screen felt abrupt.
- **Solution:** persist last theme in `sessionStorage`; restore via inline script before first paint; animate body background/color (0.25s).
- **Result:** loading screen uses previous garden colors and transitions into the new theme.