### PR TITLE
add section loading states and fade-in transitions

### DIFF
--- a/src/components/section-block.ts
+++ b/src/components/section-block.ts
@@ -49,9 +49,11 @@ class SectionBlock extends HTMLElement {
 
   async render() {
     const token = ++this.renderToken;
+    this.classList.remove('section-ready');
     if (!this.section) {
       this.replaceChildren();
       this.innerHTML = '<div class="error">Invalid section</div>';
+      this.classList.add('section-ready');
       return;
     }
 
@@ -110,6 +112,7 @@ class SectionBlock extends HTMLElement {
             onRefresh: () => this.render(),
             editMode: this.editMode,
           });
+          rendered.classList.add('content-enter');
           content.innerHTML = '';
           content.appendChild(rendered);
           break;
@@ -155,6 +158,7 @@ class SectionBlock extends HTMLElement {
         this.updateInfoBox(infoBox as HTMLElement);
       }
     }
+    this.classList.add('section-ready');
     this.replaceChildren(fragment);
   }
 
@@ -610,6 +614,7 @@ class SectionBlock extends HTMLElement {
       };
 
       const rendered = await renderRecord(record, this.section.layout || 'profile');
+      rendered.classList.add('content-enter');
       container.innerHTML = '';
       container.appendChild(rendered);
     } catch (error) {
@@ -648,7 +653,7 @@ class SectionBlock extends HTMLElement {
       }
 
       const grid = document.createElement('div');
-      grid.className = 'record-grid';
+      grid.className = 'record-grid content-enter';
 
       for (const record of records) {
         try {
@@ -735,7 +740,7 @@ class SectionBlock extends HTMLElement {
     }
 
     const contentDiv = document.createElement('div');
-    contentDiv.className = 'content';
+    contentDiv.className = 'content content-enter';
 
     try {
       if (format === 'html') {

--- a/src/components/site-renderer.ts
+++ b/src/components/site-renderer.ts
@@ -396,21 +396,26 @@ export class SiteRenderer {
             const preview = document.createElement('div');
             preview.className = 'garden-preview';
 
+            const flowerBox = document.createElement('div');
+            flowerBox.className = 'garden-preview__flower-box';
+
             const heading = document.createElement('h2');
             heading.className = 'garden-preview__heading';
             heading.textContent = "A garden could grow here.";
-            preview.appendChild(heading);
+            flowerBox.appendChild(heading);
 
-            const flowerBox = document.createElement('div');
-            flowerBox.className = 'garden-preview__flower-box';
             const flowerSize = 140;
-            flowerBox.innerHTML = generateFlowerSVGString(ownerDid!, flowerSize);
-            preview.appendChild(flowerBox);
+            const svgWrapper = document.createElement('div');
+            svgWrapper.className = 'garden-preview__flower-svg';
+            svgWrapper.innerHTML = generateFlowerSVGString(ownerDid!, flowerSize);
+            flowerBox.appendChild(svgWrapper);
 
             const subtext = document.createElement('p');
             subtext.className = 'garden-preview__subtext';
             subtext.textContent = "If this is your identity, you can login and claim your flower.";
-            preview.appendChild(subtext);
+            flowerBox.appendChild(subtext);
+
+            preview.appendChild(flowerBox);
 
             if (isOwnerLoggedIn) {
                 const editHint = document.createElement('p');

--- a/src/themes/base.css
+++ b/src/themes/base.css
@@ -200,7 +200,7 @@ site-app:not(.theme-ready) .header {
 site-app.theme-ready .main,
 site-app.theme-ready .header {
   opacity: 1;
-  transition: opacity 200ms ease-in-out;
+  animation: fadeIn 0.35s ease-out;
 }
 
 .header {
@@ -551,6 +551,11 @@ site-app.theme-ready .header {
   flex-direction: column;
 }
 
+.main:has(.homepage-view) {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 /* Add bottom padding on mobile to account for fixed save bar when in edit mode */
 @media (max-width: 767px) {
   .main:has(.save-bar) {
@@ -568,6 +573,17 @@ site-app.theme-ready .header {
 /* ============================================
    Sections
    ============================================ */
+
+/* Section blocks stay hidden until content is ready, then fade in */
+section-block:not(.section-ready) {
+  opacity: 0;
+  pointer-events: none;
+}
+
+section-block.section-ready {
+  animation: fadeIn 0.35s ease-out forwards;
+  pointer-events: auto;
+}
 
 .section {
   margin-bottom: var(--spacing-xl);
@@ -1176,6 +1192,11 @@ body.has-pattern .header:has(.controls.open) {
   line-height: 1.6;
 }
 
+/* Smooth appearance when content replaces loading state */
+.content-enter {
+  animation: fadeIn 0.3s ease-out;
+}
+
 .content h1,
 .content h2,
 .content h3 {
@@ -1489,6 +1510,7 @@ body.has-pattern .header:has(.controls.open) {
   font-size: var(--font-size-xl);
   text-transform: uppercase;
   letter-spacing: 0.1em;
+  animation: fadeIn 0.2s ease-out;
 }
 
 .error {
@@ -1508,6 +1530,7 @@ body.has-pattern .header:has(.controls.open) {
   padding: var(--spacing-xl);
   gap: var(--spacing-md);
   min-height: 200px;
+  animation: fadeIn 0.2s ease-out;
 }
 
 .loading-text {
@@ -1531,6 +1554,7 @@ body.has-pattern .header:has(.controls.open) {
   background: #fef2f2;
   border: var(--border-width) var(--border-style, solid) #dc2626;
   border-radius: 4px;
+  animation: fadeIn 0.2s ease-out;
 }
 
 .error-icon {
@@ -1571,6 +1595,7 @@ body.has-pattern .header:has(.controls.open) {
   padding: var(--spacing-xl);
   text-align: center;
   min-height: 120px;
+  animation: fadeIn 0.2s ease-out;
 }
 
 .loading-message {
@@ -1594,6 +1619,7 @@ body.has-pattern .header:has(.controls.open) {
   border: var(--border-width) var(--border-style, solid) #dc2626;
   border-radius: 0;
   min-height: 120px;
+  animation: fadeIn 0.2s ease-out;
 }
 
 .error-icon {
@@ -1668,6 +1694,7 @@ body.has-pattern .header:has(.controls.open) {
   border: var(--border-width) var(--border-style) var(--color-border);
   padding: var(--spacing-lg);
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 }
@@ -1984,6 +2011,15 @@ body.has-pattern .garden-preview__flower-box {
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
Changes to improve loading states and small fixes to UI content + styliing
 
- Hide section blocks until content is ready (section-ready class)
- Add content-enter animation for rendered content
- Introduce fadeIn keyframe for theme, loading, and error states
- Restructure garden preview elements (heading + flower + subtext in flowerBox)
- Fix homepage view margins and welcome-loading flex direction