### PR TITLE
fix isoline pattern sizing and center content layout

### DIFF
--- a/src/components/recent-gardens.ts
+++ b/src/components/recent-gardens.ts
@@ -772,7 +772,7 @@ class RecentGardens extends HTMLElement {
 
     this.innerHTML = `
       <section class="recent-gardens">
-        <h2 class="recent-gardens-title">Recent Garden Activity</h2>
+        <h2 class="recent-gardens-title">Recent garden activity</h2>
         <div class="recent-gardens-list">
           ${gardensHTML}
         </div>

--- a/src/components/site-renderer.ts
+++ b/src/components/site-renderer.ts
@@ -351,6 +351,7 @@ export class SiteRenderer {
         const sections = config.sections || [];
 
         if (isHomePage) {
+            main.classList.add('is-homepage');
             // Home page view
             const homepageView = document.createElement('div');
             homepageView.className = 'homepage-view';
@@ -517,18 +518,18 @@ export class SiteRenderer {
         renderFlowerBed({}, true).then(async flowerBedStrip => {
             // Guard against race conditions
             if (this.renderId !== myRenderId) return;
-            
+
             // Check if we should show the "Plant a flower" CTA
             // Only for logged-in visitors who haven't planted yet
             const canShowPlantCTA = isLoggedIn() && !isOwnerLoggedIn && ownerDid;
-            
+
             if (canShowPlantCTA) {
                 const currentDid = getCurrentDid();
                 const hasPlantedFlower = await this.interactions.checkHasPlantedFlower(ownerDid, currentDid);
-                
+
                 // Guard against race conditions after async check
                 if (this.renderId !== myRenderId) return;
-                
+
                 if (!hasPlantedFlower) {
                     // Create the flower bed strip if it doesn't exist (no visitors yet)
                     if (!flowerBedStrip) {
@@ -538,7 +539,7 @@ export class SiteRenderer {
                         grid.className = 'flower-grid';
                         flowerBedStrip.appendChild(grid);
                     }
-                    
+
                     // Create the CTA button
                     const plantCTA = document.createElement('button');
                     plantCTA.className = 'button button-small header-strip-cta';
@@ -546,7 +547,7 @@ export class SiteRenderer {
                     plantCTA.setAttribute('aria-label', 'Plant your flower in this garden');
                     plantCTA.title = 'Leave your unique flower in this garden';
                     plantCTA.addEventListener('click', () => this.interactions.plantFlower());
-                    
+
                     // Add CTA to the flower grid
                     const grid = flowerBedStrip.querySelector('.flower-grid');
                     if (grid) {
@@ -554,7 +555,7 @@ export class SiteRenderer {
                     }
                 }
             }
-            
+
             if (flowerBedStrip) {
                 // Insert after header, before main
                 const main = this.app.querySelector('main');

--- a/src/themes/base.css
+++ b/src/themes/base.css
@@ -102,12 +102,12 @@ body {
   line-height: 1.5;
   color: var(--color-text);
   background-color: var(--color-background);
-  /* Isoline pattern background - fixed and covers full viewport */
+  /* Isoline pattern background - fixed, 1:1 with viewport (size set in JS) */
   background-image: var(--pattern-background, none);
-  background-size: cover;
+  background-size: var(--pattern-width, auto) var(--pattern-height, auto);
   background-repeat: no-repeat;
   background-attachment: fixed;
-  background-position: center center;
+  background-position: 0 0;
   /* Smooth color transitions when navigating between gardens */
   transition: background-color 0.6s ease-in-out, color 0.6s ease-in-out;
   -webkit-font-smoothing: antialiased;
@@ -189,6 +189,9 @@ site-app {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  /* Ensure main content is centered on ultra-wide screens */
+  align-items: center;
+  width: 100%;
 }
 
 /* Theme loading state: content fades in smoothly after theme is applied */
@@ -213,6 +216,9 @@ site-app.theme-ready .header {
   padding-right: calc(var(--spacing-lg) + var(--safe-area-inset-right));
   background: var(--color-background);
   gap: var(--spacing-md);
+  /* Ensure header stretches to full width since parent is now centered */
+  width: 100%;
+  max-width: 100%;
 }
 
 .header-left {
@@ -227,11 +233,13 @@ site-app.theme-ready .header {
   display: inline-flex;
   align-items: center;
 }
+
 .header-spores > div {
   display: flex;
   align-items: center;
   justify-content: center;
 }
+
 .header-spores > div svg {
   display: block;
   /* Optical nudge: spore graphic has stem below, so shift up to align with text */
@@ -369,7 +377,7 @@ site-app.theme-ready .header {
     font-size: 1.25rem;
     max-width: 100%;
   }
-  
+
   .site-subtitle-input {
     font-size: 0.85rem;
     max-width: 100%;
@@ -380,7 +388,7 @@ site-app.theme-ready .header {
   .site-title-input {
     font-size: 1.1rem;
   }
-  
+
   .site-subtitle-input {
     font-size: 0.75rem;
   }
@@ -542,22 +550,33 @@ site-app.theme-ready .header {
   }
 }
 
+.flower-bed {
+  width: 100%;
+}
+
 .main {
   flex: 1;
+  align-self: center;
+  width: 100%;
   max-width: 1200px;
-  margin: 0 var(--spacing-lg);
+  margin: 0 auto;
   padding: var(--spacing-xl) var(--spacing-lg);
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
 }
 
-.main:has(.homepage-view) {
-  margin-left: 0;
-  margin-right: 0;
+/* Constrain homepage width for better readability */
+.main.is-homepage {
+  max-width: 1000px !important;
 }
 
 /* Add bottom padding on mobile to account for fixed save bar when in edit mode */
-@media (max-width: 767px) {
+@media (max-width: 1280px) {
+  .main {
+    padding: var(--spacing-lg) var(--spacing-md);
+  }
+
   .main:has(.save-bar) {
     padding-bottom: calc(110px + var(--safe-area-inset-bottom));
   }
@@ -600,10 +619,14 @@ body.has-pattern section-block.section {
   -webkit-backdrop-filter: blur(80px);
   border: 1px solid rgba(var(--color-text-rgb), 0.1);
   padding: var(--spacing-lg);
-  margin-left: calc(-1 * var(--spacing-lg));
-  margin-right: calc(-1 * var(--spacing-lg));
-  padding-left: var(--spacing-lg);
-  padding-right: var(--spacing-lg);
+}
+
+@media (max-width: 767px) {
+  body.has-pattern .section,
+  body.has-pattern section-block,
+  body.has-pattern section-block.section {
+    padding: var(--spacing-md);
+  }
 }
 
 /* Liquid glass effect for header and mobile menu when isoline pattern is active */
@@ -623,52 +646,23 @@ body.has-pattern .header:has(.controls.open) {
 
 /* Fallback for browsers without backdrop-filter support */
 @supports not (backdrop-filter: blur(1px)) {
+
   body.has-pattern .section,
   body.has-pattern section-block,
   body.has-pattern section-block.section {
     background: rgba(var(--color-background-rgb), 0.85) !important;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
   }
+
   body.has-pattern .header,
   body.has-pattern .controls.open {
     background: rgba(var(--color-background-rgb), 0.9) !important;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
   }
+
   body.has-pattern .garden-preview__flower-box {
     background: rgba(var(--color-background-rgb), 0.85) !important;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-  }
-}
-
-/* Reduced motion: disable pattern for accessibility */
-@media (prefers-reduced-motion: reduce) {
-  body.has-pattern {
-    background-image: none;
-  }
-  body.has-pattern .section,
-  body.has-pattern section-block {
-    background: transparent !important;
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    border-radius: 0;
-    padding: 0;
-    margin-left: 0;
-    margin-right: 0;
-    box-shadow: none;
-    border: none;
-  }
-  body.has-pattern .header,
-  body.has-pattern .controls.open {
-    background: var(--color-background);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-  }
-  body.has-pattern .garden-preview__flower-box {
-    background: var(--color-background);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    box-shadow: none;
-    border: var(--border-width) var(--border-style) var(--color-border);
   }
 }
 
@@ -1296,6 +1290,7 @@ body.has-pattern .header:has(.controls.open) {
 
 /* Form group mobile padding in modals */
 @media (max-width: 479px) {
+
   .modal-content .form-group,
   .take-flower-form {
     padding: 0 var(--spacing-md);
@@ -2018,6 +2013,7 @@ body.has-pattern .garden-preview__flower-box {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -3763,31 +3759,31 @@ body.has-pattern .garden-preview__flower-box {
     padding: var(--spacing-sm);
     padding-top: 0;
   }
-  
+
   .flower-bed.header-strip .flower-grid {
     gap: 0.375rem;
   }
-  
+
   .flower-bed.header-strip .flower-grid-item,
   .flower-bed.header-strip .flower-grid-item did-visualization,
   .flower-bed.header-strip .flower-grid-item did-visualization svg {
     width: 44px;
     height: 44px;
   }
-  
+
   .header-strip-cta {
     height: 44px;
     margin: 0;
     padding: 0 0.75rem;
     font-size: 0.75rem;
   }
-  
+
   /* Header spores - smaller on mobile to match flower bed header */
   .header-spores > div {
     width: 44px !important;
     height: 44px !important;
   }
-  
+
   .header-spores > div svg {
     width: 44px !important;
     height: 44px !important;

--- a/src/themes/marching-squares.ts
+++ b/src/themes/marching-squares.ts
@@ -174,7 +174,8 @@ export function extractContours(
   const cellWidth = width / gridWidth;
   const cellHeight = height / gridHeight;
   // Use uniform cell size for simplicity (square cells)
-  const cellSize = Math.min(cellWidth, cellHeight);
+  // Use max to ensure we cover the full area (avoiding gaps at edges); overflow is clipped
+  const cellSize = Math.max(cellWidth, cellHeight);
 
   for (const threshold of thresholds) {
     const segments: [Point, Point][] = [];


### PR DESCRIPTION
- Isoline: viewport-sized SVG via Blob URL (avoids Chrome data-URI limit),
  resize listener to refresh on window resize, aspect-ratio grid and
  marching-squares cellSize so pattern fills viewport with no gaps
- Layout: center main on wide screens, .main.is-homepage max-width 1000px,
  header/main/flower-bed full width, responsive padding at 1280px/767px
- Add main.is-homepage class in site-renderer; "Recent garden activity"
  copy; default isolines on for garden pages; drop prefers-reduced-motion
  (pattern is static)