### PR TITLE
batch profile fetches and prefer bsky for display names

### DIFF
--- a/src/components/site-data.ts
+++ b/src/components/site-data.ts
@@ -118,25 +118,26 @@ export class SiteData {
 
     /**
      * Get display name for a DID
-     * First checks for custom spores.garden profile, then falls back to Bluesky profile
+     * Prefer Bluesky profile (most users have it); optionally use garden.spores.site.profile for custom name
      */
     async getDisplayNameForDid(did: string): Promise<string | null> {
         try {
-            // First, check for custom garden.spores.site.profile record with rkey 'self'
+            const bskyProfile = await getProfile(did).catch(() => null);
+            if (bskyProfile?.displayName) {
+                return bskyProfile.displayName;
+            }
+
             const customProfile = await getRecord(did, 'garden.spores.site.profile', 'self');
             if (customProfile?.value?.displayName) {
                 return customProfile.value.displayName;
             }
 
-            // Fall back to Bluesky profile
-            const bskyProfile = await getProfile(did);
-            if (bskyProfile?.displayName) {
-                return bskyProfile.displayName;
+            if (bskyProfile?.handle) {
+                return bskyProfile.handle;
             }
 
             return null;
-        } catch (error) {
-            console.warn('Failed to get display name for DID:', error);
+        } catch {
             return null;
         }
     }

--- a/src/layouts/collected-flowers.test.ts
+++ b/src/layouts/collected-flowers.test.ts
@@ -7,8 +7,7 @@ import * as config from '../config';
 // Mock dependencies
 vi.mock('../at-client', () => ({
     listRecords: vi.fn(),
-    getRecord: vi.fn(),
-    getProfile: vi.fn()
+    getProfiles: vi.fn()
 }));
 
 vi.mock('../oauth', () => ({
@@ -72,6 +71,7 @@ describe('Collected Flowers Layout', () => {
             }
         ];
         vi.mocked(atClient.listRecords).mockResolvedValue({ records: mockFlowers, cursor: '' });
+        vi.mocked(atClient.getProfiles).mockResolvedValue(new Map());
 
         const section = { type: 'collected-flowers' };
         const el = await renderCollectedFlowers(section);
@@ -100,6 +100,7 @@ describe('Collected Flowers Layout', () => {
             }
         ];
         vi.mocked(atClient.listRecords).mockResolvedValue({ records: mockFlowers, cursor: '' });
+        vi.mocked(atClient.getProfiles).mockResolvedValue(new Map());
 
         const section = { type: 'collected-flowers' };
         const el = await renderCollectedFlowers(section);
@@ -107,6 +108,7 @@ describe('Collected Flowers Layout', () => {
         const grid = el.querySelector('.flower-grid');
         expect(grid).toBeTruthy();
         expect(atClient.listRecords).toHaveBeenCalledWith(mockOwnerDid, 'garden.spores.social.takenFlower', expect.anything());
+        expect(atClient.getProfiles).toHaveBeenCalledWith(['did:plc:source1']);
     });
 
     it('should show empty state when no flowers collected', async () => {


### PR DESCRIPTION
- Add getProfiles() in at-client (batches of 25, graceful on error)
- Collected flowers: single getProfiles(uniqueDids) instead of N getProfile + N getRecord
- getDisplayNameForDid: try Bluesky first, then garden profile; no console.warn on failure
- Use ENDPOINTS.BLUESKY_API_URL for getProfile
- Update collected-flowers tests to mock getProfiles