### PR TITLE
add backyard fill to garden bed strip

### DIFF
--- a/src/layouts/flower-bed.ts
+++ b/src/layouts/flower-bed.ts
@@ -340,7 +340,7 @@ async function showFlowerGardensModal(flowerDid: string) {
     const gardens = await findGardensWithFlower(flowerDid);
 
     if (gardens.length === 0) {
-      if (gardensList) gardensList.innerHTML = '<p>This flower hasn\'t been planted in any other garden yet.</p>';
+      if (gardensList) gardensList.innerHTML = '<h2>This flower hasn\'t been planted in any other garden yet</h2>';
       return;
     }
 
@@ -361,7 +361,7 @@ async function showFlowerGardensModal(flowerDid: string) {
     }
 
     if (gardensList?.children.length === 0) {
-      gardensList.innerHTML = '<p>This flower hasn\'t been planted in any other garden yet.</p>';
+      gardensList.innerHTML = '<h2>This flower hasn\'t been planted in any other garden yet</h2>';
     }
   } catch (error) {
     console.error('Failed to load gardens:', error);

--- a/src/themes/base.css
+++ b/src/themes/base.css
@@ -682,7 +682,8 @@ body.has-pattern .header:has(.controls.open) {
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
   }
 
-  body.has-pattern .garden-preview__flower-box {
+  body.has-pattern .garden-preview__flower-box,
+  body.has-pattern .flower-grid-item {
     background: rgba(var(--color-background-rgb), 0.85) !important;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
   }
@@ -1717,14 +1718,19 @@ body.has-pattern .header:has(.controls.open) {
   gap: var(--spacing-md);
 }
 
-/* Liquid glass effect for flower box when isoline pattern is active */
-body.has-pattern .garden-preview__flower-box {
+/* Liquid glass effect for flower box and flower grid items when isoline pattern is active */
+body.has-pattern .garden-preview__flower-box,
+body.has-pattern .flower-grid-item {
   background: rgba(var(--color-background-rgb), 0.25) !important;
   border-radius: var(--border-radius);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(80px);
   -webkit-backdrop-filter: blur(80px);
   border: 1px solid rgba(var(--color-text-rgb), 0.1);
+}
+
+body.has-pattern .flower-grid-item {
+  margin-top: var(--spacing-sm);
 }
 
 .garden-preview__heading {


### PR DESCRIPTION
- guestbook garden update:
  - flowers get a cute new look with individual backgrounds. 
  - includes [_proper_] spacing so the flower's top edge does not collide with the main header.

<img width="165" height="90" alt="image" src="https://github.com/user-attachments/assets/321d055b-af35-4fbd-b8fa-77dafecf4442" />

