### PR TITLE
Fix: Edit buttons showing on other people's gardens

### DIFF
--- a/src/components/site-app.ts
+++ b/src/components/site-app.ts
@@ -153,6 +153,7 @@ class SiteApp extends HTMLElement {
    */
   private async handleNavigation(): Promise<void> {
     try {
+      this.editor.editMode = false;
       await this.initializeAndRender(false);
     } catch (error) {
       console.error('Failed to handle navigation:', error);

--- a/src/components/site-renderer.ts
+++ b/src/components/site-renderer.ts
@@ -470,7 +470,7 @@ export class SiteRenderer {
             for (const section of activeSections) {
                 const sectionEl = document.createElement('section-block');
                 sectionEl.setAttribute('data-section', JSON.stringify(section));
-                sectionEl.setAttribute('data-edit-mode', this.editor.editMode.toString());
+                sectionEl.setAttribute('data-edit-mode', (this.editor.editMode && isOwnerLoggedIn).toString());
 
                 sectionEl.addEventListener('share-to-bluesky', () => {
                     this.interactions.shareToBluesky();
@@ -481,7 +481,7 @@ export class SiteRenderer {
         }
 
         // Add section button in edit mode
-        if (this.editor.editMode && !isHomePage) {
+        if (this.editor.editMode && isOwnerLoggedIn && !isHomePage) {
             const addBtn = document.createElement('button');
             addBtn.className = 'add-section';
             addBtn.textContent = '+ Add Section';


### PR DESCRIPTION
**Changes:** 

1. `site-app.ts:155` -> Reset `editMode = false` at the start of `handleNavigation()`, so navigating away from your garden always exits edit mode.                             
  2. `site-renderer.ts:473` -> Section edit controls now gated on `isOwnerLoggedIn` in      
  addition to `editMode`, so even if edit mode leaks, non-owners won't see delete/move/edit buttons.                                                            
  3. `site-renderer.ts:484` -> "Add Section" button now also requires `isOwnerLoggedIn`,
  preventing it from appearing on other people's gardens.