### PR TITLE
fix: clear stale inline theme styles on navigation

### DIFF
--- a/src/themes/base.css
+++ b/src/themes/base.css
@@ -3891,7 +3891,8 @@ body:has(.save-bar) .notification {
 .header-strip-cta {
   /* Slightly smaller than 48px flowers on desktop */
   height: 44px;
-  margin: 2px 0;
+  margin-top: var(--spacing-sm);
+  margin-bottom: 2px;
   padding: 0 1rem;
   font-size: 0.8rem;
   font-weight: 600;

--- a/src/themes/engine.ts
+++ b/src/themes/engine.ts
@@ -303,6 +303,9 @@ export function applyTheme(
         : null;
     };
 
+    // Clear all previous inline overrides so CSS :root defaults apply
+    root.removeAttribute('style');
+
     // Colors
     Object.entries(colors).forEach(([key, value]) => {
       if (value) {


### PR DESCRIPTION
## Summary
- `applyTheme()` sets color CSS vars as inline styles on `<html>` but never clears them — when navigating to the homepage (empty colors), the previous garden's background persists
- Fix: `root.removeAttribute('style')` before re-applying, so `:root` defaults from `base.css` take effect on pages with no custom theme
- Also fixes `.header-strip-cta` top margin using `var(--spacing-sm)` token

## Test plan
- [x] Navigate from a garden page (custom colors) to the homepage — background should reset to default
- [x] Navigate between two gardens with different color schemes — no color bleed
- [x] Verify header CTA button has proper top spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)