### PR TITLE
feat: discover gardens dynamically via relay instead of hardcoded seeds

### DIFF
--- a/src/at-client.ts
+++ b/src/at-client.ts
@@ -521,6 +521,36 @@ export async function getProfiles(actors: string[]): Promise<Map<string, unknown
 }
 
 /**
+ * List all repos (DIDs) that have records in a given collection.
+ * Calls the relay's com.atproto.sync.listReposByCollection endpoint.
+ * Paginates through all results automatically.
+ */
+export async function listReposByCollection(collection: string): Promise<string[]> {
+  const allDids: string[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const url = new URL('/xrpc/com.atproto.sync.listReposByCollection', ENDPOINTS.RELAY_URL);
+    url.searchParams.set('collection', collection);
+    if (cursor) url.searchParams.set('cursor', cursor);
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Failed to list repos by collection: ${response.status}`);
+    }
+
+    const data = await response.json();
+    for (const repo of data.repos || []) {
+      if (repo.did) allDids.push(repo.did);
+    }
+    cursor = data.cursor;
+  } while (cursor);
+
+  return allDids;
+}
+
+/**
  * Parse an AT URI into components
  */
 export function parseAtUri(uri) {

--- a/src/config/endpoints.ts
+++ b/src/config/endpoints.ts
@@ -16,5 +16,8 @@ export const ENDPOINTS = {
   CONSTELLATION_URL: env.VITE_CONSTELLATION_URL || 'https://constellation.microcosm.blue',
 
   /** Bluesky public API */
-  BLUESKY_API_URL: env.VITE_BLUESKY_API_URL || 'https://public.api.bsky.app'
+  BLUESKY_API_URL: env.VITE_BLUESKY_API_URL || 'https://public.api.bsky.app',
+
+  /** AT Protocol relay (for sync endpoints like listReposByCollection) */
+  RELAY_URL: env.VITE_RELAY_URL || 'https://relay1.us-east.bsky.network'
 } as const;


### PR DESCRIPTION
Replace the hardcoded SEED_GARDENS list with com.atproto.sync.listReposByCollection to dynamically discover all gardens from the AT Protocol relay. This finds every repo with a garden.spores.site.config record, checks activity (flower/takenFlower/spore) for all of them, and displays the most recently active ones.

- Add listReposByCollection to at-client with auto-pagination
- Add RELAY_URL endpoint (relay1.us-east.bsky.network)
- Add smart caching with 1-hour TTL for both the DID list and per-DID activity, so subsequent page loads use cache and only fetch stale/new entries
- Batch activity checks in groups of 20 to limit concurrent requests
- Increase activity cache size from 50 to 500 entries
- Keep Jetstream for real-time updates (which also refreshes the cache)