### PR TITLE
Polish homepage hero and flower help interactions

### DIFF
--- a/src/components/section-block.ts
+++ b/src/components/section-block.ts
@@ -11,6 +11,7 @@ import { renderRecord, getAvailableLayouts } from '../layouts/index';
 import { renderCollectedFlowers } from '../layouts/collected-flowers';
 import { createErrorMessage, createLoadingSpinner } from '../utils/loading-states';
 import { showConfirmModal } from '../utils/confirm-modal';
+import { createHelpTooltip } from '../utils/help-tooltip';
 import './create-profile'; // Register profile editor component
 import './create-image'; // Register image editor component
 
@@ -70,6 +71,11 @@ class SectionBlock extends HTMLElement {
     // editMode will still ensure the header container exists to hold the controls
     const shouldShowTitle = this.section.title &&
       (!isBlueskyPostSection && !this.section.hideHeader);
+    const isCollectedFlowers = this.section.type === 'collected-flowers';
+    const collectedFlowersHelp = isCollectedFlowers
+      ? createHelpTooltip('Collected flowers are a way to lead people to other gardens that you\u2019ve enjoyed visiting. You can collect a flower from someone\u2019s garden by visiting it and clicking \u201cPick A Flower\u201d.')
+      : null;
+
     let editControls: HTMLElement | null = null;
     if (shouldShowTitle || this.editMode) {
       const header = document.createElement('div');
@@ -84,6 +90,11 @@ class SectionBlock extends HTMLElement {
         title.className = 'section-title';
         title.textContent = this.section.title;
         titleContainer.appendChild(title);
+
+        // Place help tooltip inline with the title
+        if (collectedFlowersHelp) {
+          titleContainer.appendChild(collectedFlowersHelp);
+        }
       }
 
       header.appendChild(titleContainer);

--- a/src/themes/base.css
+++ b/src/themes/base.css
@@ -617,8 +617,8 @@ site-app.theme-ready .header {
   text-align: center;
   color: var(--color-text-muted);
   font-size: 0.875rem;
-  margin-top: var(--spacing-xl);
-  margin-bottom: var(--spacing-xl);
+  margin-top: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
 }
 
 .footer a {
@@ -641,7 +641,7 @@ site-app.theme-ready .header {
 .footer .hypha-credit-link:hover,
 .footer .hypha-credit-link:focus-visible,
 .footer .hypha-credit-link:active {
-  color: #000;
+  color: #9900FC;
   text-decoration-line: underline;
   text-decoration-color: #000;
   text-decoration-style: solid;
@@ -732,6 +732,12 @@ body.has-pattern .header:has(.controls.open) {
   gap: var(--spacing-md);
   flex-wrap: wrap;
   margin-bottom: var(--spacing-md);
+}
+
+.section-title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .section-title {
@@ -1718,11 +1724,62 @@ body.has-pattern .header:has(.controls.open) {
   padding: var(--spacing-xl);
   border: var(--border-width-thick) groove var(--color-border-dark);
   margin: auto 0;
+  background-color: #ffffff;
 }
 
 .homepage-view h2 {
   margin-bottom: var(--spacing-md);
   font-weight: 500;
+}
+
+/* Homepage hero */
+.homepage-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.homepage-hero__greeting {
+  font-size: 1.5rem;
+  color: #000000;
+  margin: 0;
+}
+
+.homepage-hero__heading {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.homepage-features {
+  list-style: none;
+  padding: 0;
+  margin: var(--spacing-sm) 0 0;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.homepage-features__item {
+  position: relative;
+  padding-left: 1.5em;
+  line-height: 1.5;
+  color: var(--color-text);
+}
+
+.homepage-features__item::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+}
+
+.homepage-teaser {
+  font-style: italic;
+  color: var(--color-text);
+  font-size: 0.875rem;
+  margin: var(--spacing-md) 0 0;
 }
 
 /* Homepage Mobile Responsive (Phase 10) - Extra small screens (< 480px) */
@@ -1732,6 +1789,17 @@ body.has-pattern .header:has(.controls.open) {
     text-align: center;
   }
 
+  .homepage-hero__heading {
+    font-size: 1.25rem;
+  }
+
+  .homepage-hero__greeting {
+    font-size: 1.25rem;
+  }
+
+  .homepage-features {
+    text-align: left;
+  }
 }
 
 .empty-state {
@@ -3943,6 +4011,65 @@ body:has(.save-bar) .notification {
     width: 44px !important;
     height: 44px !important;
   }
+}
+
+/* Owner flower in header strip – circular clip with accent ring */
+.flower-bed.header-strip .flower-grid-item--owner {
+  width: 56px;
+  height: 56px;
+  position: relative;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.flower-bed.header-strip .flower-grid-item--owner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 2px solid var(--color-accent, var(--color-primary, var(--color-border-dark)));
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.flower-bed.header-strip .flower-grid-item--owner did-visualization,
+.flower-bed.header-strip .flower-grid-item--owner did-visualization svg {
+  width: 56px;
+  height: 56px;
+  max-width: 56px;
+  transform: translateY(-3px);
+}
+
+@media (max-width: 479px) {
+  .flower-bed.header-strip .flower-grid-item--owner {
+    width: 52px;
+    height: 52px;
+  }
+
+  .flower-bed.header-strip .flower-grid-item--owner did-visualization,
+  .flower-bed.header-strip .flower-grid-item--owner did-visualization svg {
+    width: 52px;
+    height: 52px;
+    max-width: 52px;
+    transform: translateY(-2px);
+  }
+}
+
+/* Help tooltips – fixed positioning, viewport-aware */
+.help-tooltip {
+  position: fixed;
+  z-index: 1000;
+  display: none;
+  background: var(--color-background, #fff);
+  border: var(--border-width) var(--border-style, solid) var(--color-border-dark);
+  padding: var(--spacing-md);
+  max-width: min(360px, calc(100vw - 1rem));
+  width: max-content;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text);
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.1);
+  white-space: normal;
 }
 
 /* ============================================

--- a/src/utils/help-tooltip.ts
+++ b/src/utils/help-tooltip.ts
@@ -1,0 +1,63 @@
+/**
+ * Reusable help tooltip (?) button + tooltip popup.
+ *
+ * The tooltip is portalled to document.body so it escapes any
+ * containing blocks created by backdrop-filter / transform / etc.
+ */
+
+export function createHelpTooltip(text: string): HTMLElement {
+  const wrapper = document.createElement('span');
+  wrapper.style.position = 'relative';
+  wrapper.style.display = 'inline-flex';
+  wrapper.style.alignItems = 'center';
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'did-info-button';
+  btn.setAttribute('aria-label', 'Help');
+  btn.textContent = '?';
+
+  const tooltip = document.createElement('div');
+  tooltip.className = 'help-tooltip';
+  tooltip.setAttribute('role', 'tooltip');
+  tooltip.textContent = text;
+
+  wrapper.appendChild(btn);
+  // Tooltip lives on body, not inside the wrapper
+  document.body.appendChild(tooltip);
+
+  const position = () => {
+    const rect = btn.getBoundingClientRect();
+    const pad = 8;
+    tooltip.style.top = `${rect.bottom + pad}px`;
+
+    const tooltipWidth = tooltip.offsetWidth;
+    let left = rect.right - tooltipWidth;
+    if (left < pad) {
+      left = rect.left;
+    }
+    if (left + tooltipWidth > window.innerWidth - pad) {
+      left = window.innerWidth - pad - tooltipWidth;
+    }
+    tooltip.style.left = `${Math.max(pad, left)}px`;
+  };
+
+  const show = () => {
+    tooltip.style.display = 'block';
+    position();
+  };
+  const hide = () => { tooltip.style.display = 'none'; };
+
+  btn.addEventListener('mouseenter', show);
+  btn.addEventListener('mouseleave', hide);
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    tooltip.style.display === 'block' ? hide() : show();
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!wrapper.contains(e.target as Node)) hide();
+  });
+
+  return wrapper;
+}


### PR DESCRIPTION
- polish ahead of launch


## Changes

- Rewrote homepage hero for clearer auth-state UX (`src/components/site-renderer.ts`):
  - Logged-in users see “Welcome back, {username}!” with a teaser
  - Logged-out users keep the extended heading and login CTA
- Feature list (`ul/li`) now renders for both logged-in and logged-out users
- Added homepage isoline background and moved footer into the homepage view
- Updated greeting styles in `src/themes/base.css`:
  - Black text
  - Same size as hero heading
- Updated Hypha Coop footer link hover:
  - Text remains `#9900FC`
  - Underline is black
- Added reusable help tooltip utility (`src/utils/help-tooltip.ts`)
- Added “collected flowers” help tooltip beside section title
  (`src/components/section-block.ts`)
  - No fallback render when header is hidden
- Updated flower bed rendering to:
  - Render owner flower first
  - Tag it explicitly as `owner`
  (`src/layouts/flower-bed.ts`)
- Added owner flower circular clip/ring styling and visual centering tweaks
  (`src/themes/base.css`)
