### PR TITLE
Fix intermittent stale spore owner after capture

### DIFF
--- a/src/components/site-renderer.ts
+++ b/src/components/site-renderer.ts
@@ -183,6 +183,7 @@ export class SiteRenderer {
                             spores.forEach(spore => {
                                 const sporeEl = document.createElement('div');
                                 sporeEl.title = 'Special Spore';
+                                sporeEl.dataset.originDid = spore.originGardenDid;
                                 sporeEl.style.cursor = 'pointer';
                                 sporeEl.style.width = '60px';
                                 sporeEl.style.height = '60px';

--- a/src/components/spore-modal.ts
+++ b/src/components/spore-modal.ts
@@ -16,6 +16,17 @@ interface SporeRecord {
   rkey: string;
 }
 
+function removeHeaderSpore(originDid: string): void {
+  const sporeEl = document.querySelector(`.header-spores [data-origin-did="${originDid}"]`) as HTMLElement | null;
+  if (!sporeEl) return;
+
+  const wrap = sporeEl.parentElement as HTMLElement | null;
+  sporeEl.remove();
+  if (wrap && wrap.childElementCount === 0) {
+    wrap.remove();
+  }
+}
+
 /**
  * Find all spore records for a given origin using backlinks
  * Returns records with ownerDid derived from backlink.did
@@ -231,8 +242,8 @@ export async function showSporeDetailsModal(originGardenDid: string) {
           if (confirmed) {
             try {
               await stealSpore(originDid, visitorDid, prevHandle);
+              removeHeaderSpore(originDid);
               modal.remove();
-              window.dispatchEvent(new CustomEvent('config-updated'));
             } catch (error) {
               await showAlertModal({
                 title: 'Failed to Steal',


### PR DESCRIPTION
## Summary
- fix issue #97 where a stolen spore could remain visible in the previous holder's header until refresh
- update the UI immediately after successful capture by removing the matching header spore element in-place
- avoid a full page rerender for this interaction

## Actual Change
- `src/components/site-renderer.ts`
  - add `data-origin-did` to each rendered header spore element
- `src/components/spore-modal.ts`
  - after `stealSpore(...)` succeeds, remove the corresponding header spore via `removeHeaderSpore(originDid)`
  - remove the `config-updated` dispatch from this flow
- `src/utils/special-spore.ts`
  - ownership lookup logic remains unchanged

## Why this fixes the bug
The previous flow depended on immediate data propagation after creating the steal record. With intermittent index/backlink lag, rerender could still show stale ownership. The new flow updates the visible header state directly on success, so the stolen spore disappears on click without needing refresh.

## Testing
- `npm run build`
- manual path: open spore modal -> capture spore -> header spore disappears immediately
