### PR TITLE
mentions, hashtags, and consistent facets 🌱

### DIFF
--- a/src/components/site-interactions.ts
+++ b/src/components/site-interactions.ts
@@ -1,10 +1,11 @@
 import { getSiteOwnerDid, buildGardenPath } from '../config';
 import { isLoggedIn, getCurrentDid, createRecord, uploadBlob, post } from '../oauth';
-import { listRecords, getBacklinks, getProfile, resolveHandle } from '../at-client';
+import { listRecords, getBacklinks, getProfile } from '../at-client';
 import { getBacklinkQueries, getCollection, getReadCollections } from '../config/nsid';
 import { setCachedActivity, registerGarden } from './recent-gardens';
 import { escapeHtml } from '../utils/sanitize';
 import { generateSocialCardImage } from '../utils/social-card';
+import { detectFacets } from '../utils/facets';
 import { renderFlowerBed } from '../layouts/flower-bed';
 
 /**
@@ -248,89 +249,6 @@ export class SiteInteractions {
             return [...segmenter.segment(s)].length;
         }
 
-        async function detectFacets(text: string) {
-            const encoder = new TextEncoder();
-            type Facet = {
-                $type: 'app.bsky.richtext.facet';
-                index: { byteStart: number; byteEnd: number };
-                features: Array<
-                    | { $type: 'app.bsky.richtext.facet#link'; uri: string }
-                    | { $type: 'app.bsky.richtext.facet#mention'; did: string }
-                    | { $type: 'app.bsky.richtext.facet#tag'; tag: string }
-                >;
-            };
-            const facets: Facet[] = [];
-
-            // --- URL facets ---
-            const urlRanges: Array<{ start: number; end: number }> = [];
-            const urlRegex = /https?:\/\/[^\s\)\]\}>"']+/g;
-            let match;
-            while ((match = urlRegex.exec(text)) !== null) {
-                const url = match[0];
-                urlRanges.push({ start: match.index, end: match.index + url.length });
-                const byteStart = encoder.encode(text.slice(0, match.index)).byteLength;
-                const byteEnd = byteStart + encoder.encode(url).byteLength;
-                facets.push({ $type: 'app.bsky.richtext.facet', index: { byteStart, byteEnd }, features: [{ $type: 'app.bsky.richtext.facet#link' as const, uri: url }] });
-            }
-
-            // --- Mention facets ---
-            // Require at least one dot so bare @alice tokens are excluded
-            const mentionRegex = /@([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)/g;
-            const mentionPromises: Array<Promise<void>> = [];
-            while ((match = mentionRegex.exec(text)) !== null) {
-                const fullMatch = match[0];   // includes leading @
-                const handle = match[1];      // just the handle
-                const matchStart = match.index;
-                const matchEnd = matchStart + fullMatch.length;
-
-                // Skip if inside a URL
-                const inUrl = urlRanges.some(r => matchStart >= r.start && matchEnd <= r.end);
-                if (inUrl) continue;
-
-                const capturedStart = matchStart;
-                const capturedFull = fullMatch;
-                mentionPromises.push(
-                    resolveHandle(handle)
-                        .then(did => {
-                            const byteStart = encoder.encode(text.slice(0, capturedStart)).byteLength;
-                            const byteEnd = byteStart + encoder.encode(capturedFull).byteLength;
-                            facets.push({
-                                $type: 'app.bsky.richtext.facet',
-                                index: { byteStart, byteEnd },
-                                features: [{ $type: 'app.bsky.richtext.facet#mention' as const, did }],
-                            });
-                        })
-                        .catch(() => { /* unresolvable handle — skip silently */ })
-                );
-            }
-            await Promise.all(mentionPromises);
-
-            // --- Tag/hashtag facets ---
-            // tag field omits the leading #; byte range covers the # prefix
-            const tagRegex = /#([^\s.,;:!?'"()\[\]{}&<>#]+)/g;
-            while ((match = tagRegex.exec(text)) !== null) {
-                const fullMatch = match[0];   // includes leading #
-                const tag = match[1];         // just the tag text, no #
-                const matchStart = match.index;
-                const matchEnd = matchStart + fullMatch.length;
-
-                // Skip if inside a URL
-                const inUrl = urlRanges.some(r => matchStart >= r.start && matchEnd <= r.end);
-                if (inUrl) continue;
-
-                const byteStart = encoder.encode(text.slice(0, matchStart)).byteLength;
-                const byteEnd = byteStart + encoder.encode(fullMatch).byteLength;
-                facets.push({
-                    $type: 'app.bsky.richtext.facet',
-                    index: { byteStart, byteEnd },
-                    features: [{ $type: 'app.bsky.richtext.facet#tag' as const, tag }],
-                });
-            }
-
-            // Sort by byte position (required by AT Protocol)
-            facets.sort((a, b) => a.index.byteStart - b.index.byteStart);
-            return facets;
-        }
 
         try {
             // Generate social card

--- a/src/utils/facets.ts
+++ b/src/utils/facets.ts
@@ -1,0 +1,73 @@
+import { resolveHandle } from '../at-client';
+
+export type Facet = {
+    $type: 'app.bsky.richtext.facet';
+    index: { byteStart: number; byteEnd: number };
+    features: Array<
+        | { $type: 'app.bsky.richtext.facet#link'; uri: string }
+        | { $type: 'app.bsky.richtext.facet#mention'; did: string }
+        | { $type: 'app.bsky.richtext.facet#tag'; tag: string }
+    >;
+};
+
+export async function detectFacets(text: string): Promise<Facet[]> {
+    const encoder = new TextEncoder();
+    const facets: Facet[] = [];
+
+    // --- URL facets ---
+    const urlRanges: Array<{ start: number; end: number }> = [];
+    const urlRegex = /https?:\/\/[^\s\)\]\}>"']+/g;
+    let match;
+    while ((match = urlRegex.exec(text)) !== null) {
+        const url = match[0];
+        urlRanges.push({ start: match.index, end: match.index + url.length });
+        const byteStart = encoder.encode(text.slice(0, match.index)).byteLength;
+        const byteEnd = byteStart + encoder.encode(url).byteLength;
+        facets.push({ $type: 'app.bsky.richtext.facet', index: { byteStart, byteEnd }, features: [{ $type: 'app.bsky.richtext.facet#link', uri: url }] });
+    }
+
+    // --- Mention facets ---
+    // Require at least one dot so bare @alice tokens are excluded
+    const mentionRegex = /@([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)/g;
+    const mentionPromises: Array<Promise<void>> = [];
+    while ((match = mentionRegex.exec(text)) !== null) {
+        const fullMatch = match[0];
+        const handle = match[1];
+        const matchStart = match.index;
+        const matchEnd = matchStart + fullMatch.length;
+
+        if (urlRanges.some(r => matchStart >= r.start && matchEnd <= r.end)) continue;
+
+        const capturedStart = matchStart;
+        const capturedFull = fullMatch;
+        mentionPromises.push(
+            resolveHandle(handle)
+                .then(did => {
+                    const byteStart = encoder.encode(text.slice(0, capturedStart)).byteLength;
+                    const byteEnd = byteStart + encoder.encode(capturedFull).byteLength;
+                    facets.push({ $type: 'app.bsky.richtext.facet', index: { byteStart, byteEnd }, features: [{ $type: 'app.bsky.richtext.facet#mention', did }] });
+                })
+                .catch(() => {})
+        );
+    }
+    await Promise.all(mentionPromises);
+
+    // --- Tag/hashtag facets ---
+    // tag field omits the leading #; byte range covers the # prefix
+    const tagRegex = /#([^\s.,;:!?'"()\[\]{}&<>#]+)/g;
+    while ((match = tagRegex.exec(text)) !== null) {
+        const fullMatch = match[0];
+        const tag = match[1];
+        const matchStart = match.index;
+        const matchEnd = matchStart + fullMatch.length;
+
+        if (urlRanges.some(r => matchStart >= r.start && matchEnd <= r.end)) continue;
+
+        const byteStart = encoder.encode(text.slice(0, matchStart)).byteLength;
+        const byteEnd = byteStart + encoder.encode(fullMatch).byteLength;
+        facets.push({ $type: 'app.bsky.richtext.facet', index: { byteStart, byteEnd }, features: [{ $type: 'app.bsky.richtext.facet#tag', tag }] });
+    }
+
+    facets.sort((a, b) => a.index.byteStart - b.index.byteStart);
+    return facets;
+}


### PR DESCRIPTION
When you share your garden to Bluesky, posts now detect:

- **@mentions** — resolved to DIDs via the AT Protocol, so mentioned users get notified
- **#hashtags** — extracted and sent as tag facets
- **URLs** — same as before, now with consistent `$type` on all facets

Mentions inside garden URLs (e.g. `@charlebois.info` in `https://spores.garden/@charlebois.info`) are correctly skipped. Unresolvable handles are silently ignored.