### PR TITLE
fix mobile header spores wrapping

### DIFF
--- a/src/components/site-renderer.ts
+++ b/src/components/site-renderer.ts
@@ -94,7 +94,6 @@ export class SiteRenderer {
         const leftGroup = document.createElement('div');
         leftGroup.className = 'header-left';
         leftGroup.style.display = 'flex';
-        leftGroup.style.flexWrap = 'wrap';
         leftGroup.style.alignItems = 'self-start';
         leftGroup.style.gap = '1rem';
 
@@ -112,12 +111,22 @@ export class SiteRenderer {
             homeButton.innerHTML = this.getDandelionIcon();
         }
 
-        leftGroup.appendChild(homeButton);
+        // Inner row: home button + title always stay on the same line
+        const topRow = document.createElement('div');
+        topRow.style.display = 'flex';
+        topRow.style.gap = '1rem';
+        topRow.style.flexWrap = 'nowrap';
+        topRow.style.flex = '1';
+        topRow.style.minWidth = '0';
+        topRow.appendChild(homeButton);
+        leftGroup.appendChild(topRow);
 
         // Title and subtitle container
         const titleContainer = document.createElement('div');
         titleContainer.style.display = 'flex';
         titleContainer.style.flexDirection = 'column';
+        titleContainer.style.flex = '1';
+        titleContainer.style.minWidth = '0';
 
         // When in edit mode and owner is logged in, show editable inputs
         if (this.editor.editMode && isOwnerLoggedIn && !isHomePage) {
@@ -214,7 +223,7 @@ export class SiteRenderer {
             }
         }
 
-        leftGroup.appendChild(titleContainer);
+        topRow.appendChild(titleContainer);
         header.appendChild(leftGroup);
 
         // Controls

--- a/src/themes/base.css
+++ b/src/themes/base.css
@@ -511,17 +511,22 @@ site-app.theme-ready .header {
     flex: 1;
     min-width: 0;
     overflow: visible;
-    flex-wrap: nowrap !important;
-    /* Prevent wrapping - keep title on same line as home button */
+    flex-wrap: wrap;
   }
 
-  /* Title container should flex and allow text wrapping */
-  .header-left > div {
+  /* topRow (inner container) and any non-spores direct child */
+  .header-left > div:not(.header-spores) {
     flex: 1;
     min-width: 0;
     max-width: 100%;
     overflow-wrap: break-word;
     word-wrap: break-word;
+  }
+
+  /* Push spores onto their own line below the title row */
+  .header-spores {
+    flex-basis: 100%;
+    flex-wrap: wrap;
   }
 
   .site-info {


### PR DESCRIPTION

## Summary
Mobile gardens with 4+ spores had a content overlap issue.
Solution is to bring spores container on a second line when needed
 
- Wraps home button + title in an inner `topRow` div (nowrap) so they always stay on one line
- `header-left` becomes the wrapping container, allowing `header-spores` to flow onto a second line on narrow screens instead of overlapping the hamburger menu
- Removes `flex-wrap: nowrap !important` from mobile CSS in favour of the structural fix

## Test plan

- [x] Mobile emulation ≤ 767px: profiles with 3+ spores show spores row below title/home button, no overlap with hamburger
- [x] Home button and title stay on the same line regardless of spore count
- [x] Long usernames wrap within the title container without breaking layout
- [x] Desktop (> 767px) layout unchanged