### PR TITLE
Fix: remove useSlingshot from all getRecord calls

### DIFF
--- a/src/components/recent-gardens.ts
+++ b/src/components/recent-gardens.ts
@@ -330,8 +330,8 @@ class RecentGardens extends HTMLElement {
     // For non-config records, verify the user has a garden
     if (updateType !== 'edit') {
       try {
-        const configRecord = await getRecord(gardenDid, getCollection('siteConfig', 'old'), 'self', { useSlingshot: true })
-          || await getRecord(gardenDid, getCollection('siteConfig', 'new'), 'self', { useSlingshot: true });
+        const configRecord = await getRecord(gardenDid, getCollection('siteConfig', 'old'), 'self')
+          || await getRecord(gardenDid, getCollection('siteConfig', 'new'), 'self');
         if (!configRecord?.value) return;
       } catch {
         return;

--- a/src/components/spore-modal.ts
+++ b/src/components/spore-modal.ts
@@ -47,8 +47,7 @@ async function findSporeRecordsByOrigin(originGardenDid: string): Promise<SporeR
           const record = await getRecord(
             bl.did,
             bl.collection || SPECIAL_SPORE_COLLECTION,
-            bl.rkey,
-            { useSlingshot: true }
+            bl.rkey
           );
           if (!record?.value) return null;
           return {

--- a/src/utils/special-spore.ts
+++ b/src/utils/special-spore.ts
@@ -54,7 +54,7 @@ export async function findSporeByOrigin(originGardenDid: string): Promise<SporeI
     const records = await Promise.all(
       backlinks.map(async (bl) => {
         try {
-          return await getRecord(bl.did, bl.collection || SPECIAL_SPORE_COLLECTION, bl.rkey, { useSlingshot: true });
+          return await getRecord(bl.did, bl.collection || SPECIAL_SPORE_COLLECTION, bl.rkey);
         } catch {
           return null;
         }


### PR DESCRIPTION
Slingshot is returning CORS errors from spores.garden, blocking the rendering of spores. It seems to also affects some of the recent garden activity.

All three `useSlingshot: true` callsites are removed so requests go through the normal PDS resolution path, with Slingshot as a fallback rather than the primary target.

Affected:
- `src/utils/special-spore.ts` — spore origin lookup
- `src/components/spore-modal.ts` — spore trajectory
- `src/components/recent-gardens.ts` — real-time garden config verification