### PR TITLE
speed up special spores loading in header

### DIFF
--- a/src/components/site-app.ts
+++ b/src/components/site-app.ts
@@ -99,12 +99,16 @@ class SiteApp extends HTMLElement {
     
     // Initialize config with current URL params
     const config = await initConfig();
-    
+
     // Always apply theme (including home page) so fonts-ready is set and text isn't hidden.
     // On the homepage, use default theme — never apply a garden's custom colors or background.
     // On navigation, don't block on font loading (big perf win when gardens use different fonts).
     const isGardenPage = SiteRouter.isViewingProfile();
     const did = isGardenPage ? getSiteOwnerDid() : undefined;
+
+    // Prefetch spores now so the network request runs in parallel with font loading
+    if (did) this.renderer.prefetchSpores(did);
+
     await applyTheme(isGardenPage ? config.theme : {}, { waitForFonts: isInitialLoad, did: did || undefined });
     
     // On initial load, set up theme-ready state


### PR DESCRIPTION
## Summary

- Prefetch spores immediately after `initConfig()` resolves (before `applyTheme()`), so the network fetch runs in parallel with font loading instead of after it
- Parallelize `findAllHeldSpores()`: replace the sequential `for...of + await` loop with `Promise.all()` so N spores cost 1× round-trip instead of N×
- Cache the in-flight promise on `SiteRenderer` so the prefetched result is reused when the header renders

## Test plan

- [x] Navigate to a garden that holds a special spore — flower icon should appear in the header noticeably faster
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (155 tests)