### PR TITLE
Deduplicate header spores across NSID aliases

### DIFF
--- a/src/components/site-renderer.ts
+++ b/src/components/site-renderer.ts
@@ -185,7 +185,12 @@ export class SiteRenderer {
                     this.sporesCache = null;
                     sporesPromise.then(spores => {
                         if (this.renderId !== myRenderId) return;
-                        if (spores.length > 0) {
+                        const uniqueSpores = spores.filter((spore, index, all) =>
+                            !!spore?.originGardenDid &&
+                            all.findIndex((candidate) => candidate.originGardenDid === spore.originGardenDid) === index
+                        );
+                        if (uniqueSpores.length > 0) {
+                            leftGroup.querySelector('.header-spores')?.remove();
                             const sporesWrap = document.createElement('div');
                             sporesWrap.className = 'header-spores';
                             sporesWrap.style.display = 'flex';
@@ -194,7 +199,7 @@ export class SiteRenderer {
                             sporesWrap.style.marginTop = '0';
                             sporesWrap.style.alignItems = 'center';
 
-                            spores.forEach(spore => {
+                            uniqueSpores.forEach(spore => {
                                 const sporeEl = document.createElement('div');
                                 sporeEl.title = 'Special Spore';
                                 sporeEl.dataset.originDid = spore.originGardenDid;

--- a/src/utils/special-spore.test.ts
+++ b/src/utils/special-spore.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { findSporeByOrigin, stealSpore } from './special-spore';
-import { getBacklinks, getRecord } from '../at-client';
+import { findAllHeldSpores, findSporeByOrigin, stealSpore } from './special-spore';
+import { getBacklinks, getRecord, listRecords } from '../at-client';
 import { createRecord } from '../oauth';
+import { isValidSpore } from '../config';
 import { showAlertModal } from './confirm-modal';
 import { getCollection } from '../config/nsid';
 
 vi.mock('../at-client', () => ({
   getBacklinks: vi.fn(),
   getRecord: vi.fn(),
+  listRecords: vi.fn(),
 }));
 
 vi.mock('../oauth', () => ({
@@ -29,6 +31,7 @@ describe('special spore guardrails', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(now);
+    vi.mocked(isValidSpore).mockImplementation((did: string) => did === 'did:plc:origin');
   });
 
   it('ignores implausible future-timestamp records when resolving holder', async () => {
@@ -97,5 +100,41 @@ describe('special spore guardrails', () => {
       subject: 'did:plc:origin',
     }));
     expect(showAlertModal).toHaveBeenCalled();
+  });
+
+  it('deduplicates held spores returned from old and new collections', async () => {
+    vi.mocked(listRecords).mockResolvedValue({
+      records: [
+        {
+          value: {
+            subject: 'did:plc:origin',
+          },
+        },
+      ],
+    } as any);
+
+    vi.mocked(getBacklinks).mockResolvedValue({
+      records: [
+        { did: 'did:plc:holder', collection: 'garden.spores.item.specialSpore', rkey: 'abc' },
+      ],
+    } as any);
+
+    vi.mocked(getRecord).mockResolvedValue({
+      value: {
+        subject: 'did:plc:origin',
+        createdAt: '2026-02-16T11:58:00.000Z',
+      },
+    } as any);
+
+    const result = await findAllHeldSpores('did:plc:holder');
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        originGardenDid: 'did:plc:origin',
+        currentOwnerDid: 'did:plc:holder',
+      }),
+    ]);
+    expect(getBacklinks).toHaveBeenCalledTimes(2);
+    expect(getRecord).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/special-spore.ts
+++ b/src/utils/special-spore.ts
@@ -109,11 +109,12 @@ export async function findAllHeldSpores(gardenOwnerDid: string): Promise<SporeIn
     const sporeRecords = ownedResponses.flatMap((response: any) => response.records || []);
 
     const alreadyFound = new Set(heldSpores.map(s => s.originGardenDid));
-    const candidates = sporeRecords
+    const candidateOrigins = sporeRecords
       .map(r => r.value?.subject)
       .filter((originDid): originDid is string =>
         !!originDid && isValidSpore(originDid) && !alreadyFound.has(originDid)
       );
+    const candidates = Array.from(new Set(candidateOrigins));
     const fetched = await Promise.all(candidates.map(findSporeByOrigin));
     for (const spore of fetched) {
       if (spore && spore.currentOwnerDid === gardenOwnerDid) heldSpores.push(spore);

--- a/src/utils/special-spore.ts
+++ b/src/utils/special-spore.ts
@@ -19,6 +19,17 @@ export interface SporeInfo {
   currentRecord: any;
 }
 
+function dedupeSporesByOrigin(spores: SporeInfo[]): SporeInfo[] {
+  const seen = new Set<string>();
+  return spores.filter((spore) => {
+    if (!spore?.originGardenDid || seen.has(spore.originGardenDid)) {
+      return false;
+    }
+    seen.add(spore.originGardenDid);
+    return true;
+  });
+}
+
 function parseCaptureTimestampMs(createdAt: unknown, nowMs = Date.now()): number | null {
   if (typeof createdAt !== 'string' || !createdAt) {
     return null;
@@ -120,10 +131,10 @@ export async function findAllHeldSpores(gardenOwnerDid: string): Promise<SporeIn
       if (spore && spore.currentOwnerDid === gardenOwnerDid) heldSpores.push(spore);
     }
 
-    return heldSpores;
+    return dedupeSporesByOrigin(heldSpores);
   } catch (error) {
     console.error('Failed to find held spores:', error);
-    return heldSpores;
+    return dedupeSporesByOrigin(heldSpores);
   }
 }
 


### PR DESCRIPTION
## Summary
- deduplicate held spores by origin DID when aggregating old and new special spore collections
- deduplicate header spores before rendering and clear any stale header spore container before re-rendering
- add regression coverage for old/new collection overlap so the same spore does not render twice

## Verification
- /tmp/spores-garden-prod-dedupe/node_modules/.bin/vitest run src/utils/special-spore.test.ts
- /tmp/spores-garden-prod-dedupe/node_modules/.bin/vite build