### PR TITLE
add flower web tile section type

### DIFF
--- a/client-metadata.json
+++ b/client-metadata.json
@@ -5,7 +5,7 @@
   "redirect_uris": [
     "http://127.0.0.1:5174/"
   ],
-  "scope": "atproto blob:*/* repo:app.bsky.feed.post?action=create repo:coop.hypha.spores.content.image repo:coop.hypha.spores.content.text repo:coop.hypha.spores.item.specialSpore repo:coop.hypha.spores.site.config repo:coop.hypha.spores.site.layout repo:coop.hypha.spores.site.profile repo:coop.hypha.spores.site.section repo:coop.hypha.spores.social.flower repo:coop.hypha.spores.social.takenFlower repo:garden.spores.content.image repo:garden.spores.content.text repo:garden.spores.item.specialSpore repo:garden.spores.site.config repo:garden.spores.site.layout repo:garden.spores.site.profile repo:garden.spores.site.sections repo:garden.spores.site.section repo:garden.spores.social.flower repo:garden.spores.social.takenFlower",
+  "scope": "atproto blob:*/* repo:app.bsky.feed.post?action=create repo:coop.hypha.spores.content.image repo:coop.hypha.spores.content.text repo:coop.hypha.spores.item.specialSpore repo:coop.hypha.spores.site.config repo:coop.hypha.spores.site.layout repo:coop.hypha.spores.site.profile repo:coop.hypha.spores.site.section repo:coop.hypha.spores.social.flower repo:coop.hypha.spores.social.takenFlower repo:ing.dasl.masl repo:garden.spores.content.image repo:garden.spores.content.text repo:garden.spores.item.specialSpore repo:garden.spores.site.config repo:garden.spores.site.layout repo:garden.spores.site.profile repo:garden.spores.site.sections repo:garden.spores.site.section repo:garden.spores.social.flower repo:garden.spores.social.takenFlower",
   "grant_types": [
     "authorization_code",
     "refresh_token"

--- a/lexicons/ing/dasl/masl.json
+++ b/lexicons/ing/dasl/masl.json
@@ -1,0 +1,161 @@
+{
+  "lexicon": 1,
+  "id": "ing.dasl.masl",
+  "description": "Lexicon for DASL (https://dasl.ing/) types used on AT, notably for Web Tiles.",
+  "defs": {
+    "masl": {
+      "type": "object",
+      "description": "MASL metadata as defined in https://dasl.ing/masl.html",
+      "closed": false,
+      "required": [
+        "name",
+        "resources"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name for the tile, can be a title or app name",
+          "maxLength": 1000,
+          "maxGraphemes": 100
+        },
+        "description": {
+          "type": "string",
+          "description": "Short overview of the content",
+          "maxLength": 3000,
+          "maxGraphemes": 300
+        },
+        "categories": {
+          "type": "array",
+          "description": "Tags categorising the tile",
+          "items": {
+            "type": "string"
+          }
+        },
+        "background_color": {
+          "type": "string",
+          "description": "A colour for the background of the tile"
+        },
+        "icons": {
+          "type": "array",
+          "description": "Icons for the tile",
+          "items": {
+            "type": "object",
+            "required": [
+              "src"
+            ],
+            "properties": {
+              "src": {
+                "type": "string",
+                "description": "Path to a resource entry"
+              },
+              "sizes": {
+                "type": "string"
+              },
+              "purpose": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "screenshots": {
+          "type": "array",
+          "description": "Screenshots, can be used for banner or card images",
+          "items": {
+            "type": "object",
+            "required": [
+              "src"
+            ],
+            "properties": {
+              "src": {
+                "type": "string",
+                "description": "Path to a resource entry"
+              },
+              "sizes": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "sizing": {
+          "type": "object",
+          "description": "Requesting sizing properties for the content",
+          "required": [
+            "width",
+            "height"
+          ],
+          "properties": {
+            "width": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "height": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "resources": {
+          "type": "unknown",
+          "description": "A mapping of path to object with a CID src and HTTP headers"
+        },
+        "short_name": {
+          "type": "string",
+          "description": "A name, in case the basic name cannot fit"
+        },
+        "theme_color": {
+          "type": "string",
+          "description": "Theme colour"
+        },
+        "prev": {
+          "type": "cid-link",
+          "description": "In case there are multiple versions of this tile, this is the CID of the previous one"
+        },
+        "version": {
+          "type": "integer",
+          "description": "The CAR version - avoid using this",
+          "const": 1
+        },
+        "roots": {
+          "type": "array",
+          "description": "The CAR roots - avoid using this",
+          "items": {
+            "type": "cid-link"
+          }
+        }
+      }
+    },
+    "main": {
+      "type": "record",
+      "description": "A tile, instantiating MASL metadata into a record",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "cid",
+          "tile",
+          "createdAt"
+        ],
+        "properties": {
+          "cid": {
+            "type": "string",
+            "description": "The DRISL CID of the MASL for the tile",
+            "format": "cid"
+          },
+          "tile": {
+            "type": "ref",
+            "description": "The MASL content",
+            "ref": "#masl"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Timestamp",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@atcute/cbor": "^2.3.2",
+        "@atcute/cid": "^2.4.1",
         "@atcute/client": "^4.2.1",
         "@atcute/identity-resolver": "^1.2.2",
         "@atcute/oauth-browser-client": "^2.0.3",
@@ -71,6 +73,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@atcute/cbor": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@atcute/cbor/-/cbor-2.3.2.tgz",
+      "integrity": "sha512-xP2SORSau/VVI00x2V4BjwIkHr6EQ7l/MXEOPaa4LGYtePFc4gnD4L1yN10dT5NEuUnvGEuCh6arLB7gz1smVQ==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/cid": "^2.4.1",
+        "@atcute/multibase": "^1.1.8",
+        "@atcute/uint8array": "^1.1.1"
+      }
+    },
+    "node_modules/@atcute/cid": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@atcute/cid/-/cid-2.4.1.tgz",
+      "integrity": "sha512-bwhna69RCv7yetXudtj+2qrMPYvhhIQqvJz6YUpUS98v7OdF3X2dnye9Nig2NDrklZcuyOsu7sQo7GOykJXRLQ==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/multibase": "^1.1.8",
+        "@atcute/uint8array": "^1.1.1"
+      }
+    },
     "node_modules/@atcute/client": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@atcute/client/-/client-4.2.1.tgz",
@@ -118,12 +141,12 @@
       }
     },
     "node_modules/@atcute/multibase": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@atcute/multibase/-/multibase-1.1.6.tgz",
-      "integrity": "sha512-HBxuCgYLKPPxETV0Rot4VP9e24vKl8JdzGCZOVsDaOXJgbRZoRIF67Lp0H/OgnJeH/Xpva8Z5ReoTNJE5dn3kg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@atcute/multibase/-/multibase-1.2.0.tgz",
+      "integrity": "sha512-ZK2GRra+qIYq9nNuQB52m2ul0hOmCQEtPobGfTSUxm7pF0OGEkWGkWHugFhNEDVzHzTwPxHp6VGotdZFue4lYQ==",
       "license": "0BSD",
       "dependencies": {
-        "@atcute/uint8array": "^1.0.5"
+        "@atcute/uint8array": "^1.1.1"
       }
     },
     "node_modules/@atcute/oauth-browser-client": {
@@ -141,9 +164,9 @@
       }
     },
     "node_modules/@atcute/uint8array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@atcute/uint8array/-/uint8array-1.0.6.tgz",
-      "integrity": "sha512-ucfRBQc7BFT8n9eCyGOzDHEMKF/nZwhS2pPao4Xtab1ML3HdFYcX2DM1tadCzas85QTGxHe5urnUAAcNKGRi9A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@atcute/uint8array/-/uint8array-1.1.1.tgz",
+      "integrity": "sha512-3LsC8XB8TKe9q/5hOA5sFuzGaIFdJZJNewC5OKa3o/eU6+K7JR6see9Zy2JbQERNVnRl11EzbNov1efgLMAs4g==",
       "license": "0BSD"
     },
     "node_modules/@atcute/util-fetch": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@atcute/cbor": "^2.3.2",
+    "@atcute/cid": "^2.4.1",
     "@atcute/client": "^4.2.1",
     "@atcute/identity-resolver": "^1.2.2",
     "@atcute/oauth-browser-client": "^2.0.3",

--- a/public/client-metadata.json
+++ b/public/client-metadata.json
@@ -5,7 +5,7 @@
     "redirect_uris": [
         "https://spores.garden/"
     ],
-    "scope": "atproto blob:*/* repo:app.bsky.feed.post?action=create repo:coop.hypha.spores.content.image repo:coop.hypha.spores.content.text repo:coop.hypha.spores.item.specialSpore repo:coop.hypha.spores.site.config repo:coop.hypha.spores.site.layout repo:coop.hypha.spores.site.profile repo:coop.hypha.spores.site.section repo:coop.hypha.spores.social.flower repo:coop.hypha.spores.social.takenFlower repo:garden.spores.content.image repo:garden.spores.content.text repo:garden.spores.item.specialSpore repo:garden.spores.site.config repo:garden.spores.site.layout repo:garden.spores.site.profile repo:garden.spores.site.sections repo:garden.spores.site.section repo:garden.spores.social.flower repo:garden.spores.social.takenFlower",
+    "scope": "atproto blob:*/* repo:app.bsky.feed.post?action=create repo:coop.hypha.spores.content.image repo:coop.hypha.spores.content.text repo:coop.hypha.spores.item.specialSpore repo:coop.hypha.spores.site.config repo:coop.hypha.spores.site.layout repo:coop.hypha.spores.site.profile repo:coop.hypha.spores.site.section repo:coop.hypha.spores.social.flower repo:coop.hypha.spores.social.takenFlower repo:ing.dasl.masl repo:garden.spores.content.image repo:garden.spores.content.text repo:garden.spores.item.specialSpore repo:garden.spores.site.config repo:garden.spores.site.layout repo:garden.spores.site.profile repo:garden.spores.site.sections repo:garden.spores.site.section repo:garden.spores.social.flower repo:garden.spores.social.takenFlower",
     "grant_types": [
         "authorization_code",
         "refresh_token"

--- a/src/components/section-block.ts
+++ b/src/components/section-block.ts
@@ -139,6 +139,9 @@ class SectionBlock extends HTMLElement {
         case 'share-to-bluesky':
           await this.renderShareToBluesky(content);
           break;
+        case 'web-tile':
+          await this.renderWebTile(content);
+          break;
         default:
           content.innerHTML = `<p>Unknown section type: ${this.section.type}</p>`;
       }
@@ -366,6 +369,8 @@ class SectionBlock extends HTMLElement {
       typeInfo = 'Loading...';
     } else if (this.section.type === 'share-to-bluesky') {
       typeInfo = 'Share on Bluesky';
+    } else if (this.section.type === 'web-tile') {
+      typeInfo = 'Web Tile';
     } else {
       typeInfo = this.section.type.charAt(0).toUpperCase() + this.section.type.slice(1);
     }
@@ -832,6 +837,65 @@ class SectionBlock extends HTMLElement {
 
     buttonContainer.appendChild(button);
     container.appendChild(buttonContainer);
+  }
+
+  async renderWebTile(container) {
+    const tileUri = this.section.tileUri || this.section.ref;
+    if (!tileUri) {
+      container.innerHTML = '<p>No tile URI configured</p>';
+      return;
+    }
+
+    const parsed = parseAtUri(tileUri);
+    if (!parsed) {
+      container.innerHTML = '<p>Invalid tile URI</p>';
+      return;
+    }
+
+    if (parsed.collection !== 'ing.dasl.masl') {
+      container.innerHTML = '<p>Invalid tile: unexpected record type</p>';
+      return;
+    }
+
+    try {
+      const record = await getRecord(parsed.did, parsed.collection, parsed.rkey);
+      const root = record?.value?.resources?.['/'];
+      if (!root?.src) {
+        container.innerHTML = '<p>Tile record missing resources</p>';
+        return;
+      }
+
+      if (root['content-type'] !== 'text/html') {
+        container.innerHTML = '<p>Tile resource is not an HTML document</p>';
+        return;
+      }
+
+      const blobUrl = await getBlobUrl(parsed.did, root.src);
+      const response = await fetch(blobUrl);
+      if (!response.ok) {
+        throw new Error(`Blob fetch failed: ${response.status}`);
+      }
+      const html = await response.text();
+
+      const sizing = record.value.sizing || { width: 300, height: 300 };
+
+      const iframe = document.createElement('iframe');
+      iframe.srcdoc = html;
+      iframe.sandbox.add('allow-scripts');
+      iframe.style.width = `${sizing.width}px`;
+      iframe.style.height = `${sizing.height}px`;
+      iframe.style.maxWidth = '100%';
+      iframe.style.border = 'none';
+      iframe.style.borderRadius = '12px';
+      iframe.style.display = 'block';
+      iframe.style.margin = '0 auto';
+      iframe.title = record.value.name || 'Web Tile';
+
+      container.appendChild(iframe);
+    } catch (error) {
+      console.error('Failed to render web tile:', error);
+      container.innerHTML = '<p>Failed to load tile</p>';
+    }
   }
 
 }

--- a/src/components/section-block.ts
+++ b/src/components/section-block.ts
@@ -859,13 +859,15 @@ class SectionBlock extends HTMLElement {
 
     try {
       const record = await getRecord(parsed.did, parsed.collection, parsed.rkey);
-      const root = record?.value?.resources?.['/'];
+      const tile = record?.value?.tile ?? record?.value;
+      const root = tile?.resources?.['/'];
       if (!root?.src) {
         container.innerHTML = '<p>Tile record missing resources</p>';
         return;
       }
 
-      if (root['content-type'] !== 'text/html') {
+      const contentType = (root['content-type'] || '').split(';')[0].trim().toLowerCase();
+      if (contentType !== 'text/html') {
         container.innerHTML = '<p>Tile resource is not an HTML document</p>';
         return;
       }
@@ -877,7 +879,7 @@ class SectionBlock extends HTMLElement {
       }
       const html = await response.text();
 
-      const sizing = record.value.sizing || { width: 300, height: 300 };
+      const sizing = tile.sizing || { width: 300, height: 300 };
 
       const iframe = document.createElement('iframe');
       iframe.srcdoc = html;
@@ -889,7 +891,7 @@ class SectionBlock extends HTMLElement {
       iframe.style.borderRadius = '12px';
       iframe.style.display = 'block';
       iframe.style.margin = '0 auto';
-      iframe.title = record.value.name || 'Web Tile';
+      iframe.title = tile.name || 'Web Tile';
 
       container.appendChild(iframe);
     } catch (error) {

--- a/src/components/site-editor.ts
+++ b/src/components/site-editor.ts
@@ -6,6 +6,7 @@ import { getCollection } from '../config/nsid';
 import { setCachedActivity } from './recent-gardens';
 import { escapeHtml } from '../utils/sanitize';
 import { parseBskyPostUrl } from '../utils/bsky-url';
+import { publishFlowerTile } from '../tiles/tile-publisher';
 import './create-content';
 
 /**
@@ -89,6 +90,10 @@ export class SiteEditor {
             <span class="icon">🌼</span>
             <span>Collected Flowers</span>
           </button>
+          <button data-type="web-tile" class="section-type">
+            <span class="icon">🌸</span>
+            <span>Flower Tile</span>
+          </button>
           <button data-action="load-records" class="section-type">
             <span class="icon">📚</span>
             <span>Load Records</span>
@@ -152,6 +157,12 @@ export class SiteEditor {
     // If it's profile, check for existing or clone from Bluesky
     if (type === 'profile') {
       this.addProfileSection();
+      return;
+    }
+
+    // If it's web-tile, publish the flower tile and add the section
+    if (type === 'web-tile') {
+      this.addFlowerTileSection();
       return;
     }
 
@@ -267,6 +278,29 @@ export class SiteEditor {
     }
   }
 
+  async addFlowerTileSection() {
+    const did = getCurrentDid();
+    if (!did) {
+      this.showNotification('You must be logged in to add a flower tile.', 'error');
+      return;
+    }
+
+    this.showNotification('Publishing flower tile...', 'success');
+
+    try {
+      const { uri } = await publishFlowerTile(did);
+      this.addSectionToConfig({
+        type: 'web-tile',
+        ref: uri,
+        title: 'My Flower'
+      });
+      this.showNotification('Flower tile added!', 'success');
+    } catch (error) {
+      console.error('Failed to publish flower tile:', error);
+      this.showNotification('Failed to publish flower tile.', 'error');
+    }
+  }
+
   addSectionToConfig(params: { type: string, collection?: string, rkey?: string, title?: string, ref?: string }) {
     const config = getConfig();
     const id = `section-${Date.now()}`;
@@ -280,6 +314,10 @@ export class SiteEditor {
     if (params.type === 'collected-flowers') {
       section.layout = 'collected-flowers';
       section.title = 'Collected Flowers';
+    }
+
+    if (params.type === 'web-tile') {
+      section.layout = 'web-tile';
     }
 
     if (params.ref) {

--- a/src/oauth-scope.ts
+++ b/src/oauth-scope.ts
@@ -11,6 +11,7 @@ export const ATPROTO_GRANULAR_SCOPE = [
   'repo:coop.hypha.spores.site.section',
   'repo:coop.hypha.spores.social.flower',
   'repo:coop.hypha.spores.social.takenFlower',
+  'repo:ing.dasl.masl',
   'repo:garden.spores.content.image',
   'repo:garden.spores.content.text',
   'repo:garden.spores.item.specialSpore',

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -596,6 +596,27 @@ export async function uploadBlob(blob: Blob, mimeType: string) {
     throw new Error('Missing OAuth session');
   }
 
+  // Resolve PDS so we can log the actual endpoint being hit (the agent uses its own
+  // resolved service internally; this is logged for diagnosis).
+  let resolvedPds: string | undefined;
+  try {
+    if (identityResolver) {
+      const resolved = await identityResolver.resolve(currentSession.info.sub as any);
+      if (resolved?.pds) resolvedPds = resolved.pds;
+    }
+  } catch {
+    // Non-fatal — logging will note unknown PDS.
+  }
+
+  console.log('[uploadBlob] request', {
+    pds: resolvedPds || '(unresolved — agent default)',
+    endpoint: '/xrpc/com.atproto.repo.uploadBlob',
+    mimeType,
+    blobSize: blob.size,
+    blobType: blob.type,
+    did: currentSession.info.sub
+  });
+
   // Use the OAuthUserAgent.handle() method which automatically handles
   // DPoP authentication (AT Protocol OAuth doesn't use simple Bearer tokens)
   try {
@@ -607,17 +628,42 @@ export async function uploadBlob(blob: Blob, mimeType: string) {
       body: blob
     });
 
+    const requestId = response.headers.get('x-request-id')
+      || response.headers.get('x-amzn-requestid')
+      || response.headers.get('cf-ray')
+      || null;
+
     if (!response.ok) {
+      // Read the raw body once so we can both log it and parse it.
+      const rawBody = await response.text().catch(() => '');
+      let parsed: any = null;
+      try { parsed = rawBody ? JSON.parse(rawBody) : null; } catch { /* not JSON */ }
+
+      console.error('[uploadBlob] failed', {
+        status: response.status,
+        statusText: response.statusText,
+        requestId,
+        contentType: response.headers.get('content-type'),
+        rawBody: rawBody.slice(0, 2000),
+        parsed
+      });
+
       if (response.status === 401 || response.status === 403) {
         clearSessionDueToAuthFailure();
         throw new Error('Session expired, please log in again.');
       }
-      const errorData = await response.json().catch(() => ({}));
-      const errorMsg = errorData.message || errorData.error || `HTTP ${response.status}`;
+      const errorMsg = parsed?.message || parsed?.error || `HTTP ${response.status}`;
       throw new Error(`Failed to upload blob: ${errorMsg}`);
     }
 
     const data = await response.json();
+    console.log('[uploadBlob] success', {
+      status: response.status,
+      requestId,
+      blobRef: data?.blob,
+      blobMimeType: data?.blob?.mimeType,
+      blobSize: data?.blob?.size
+    });
 
     // Return response in the same format as other functions (with ok and data properties)
     return {
@@ -625,7 +671,7 @@ export async function uploadBlob(blob: Blob, mimeType: string) {
       data: data
     };
   } catch (error) {
-    console.error('uploadBlob error:', error);
+    console.error('[uploadBlob] error', error);
     throw error;
   }
 }

--- a/src/tiles/flower-tile.test.ts
+++ b/src/tiles/flower-tile.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { generateFlowerTileHTML } from './flower-tile';
+
+const TEST_DID = 'did:plc:abc123testdid';
+
+describe('generateFlowerTileHTML', () => {
+  it('returns a valid HTML document', () => {
+    const html = generateFlowerTileHTML(TEST_DID);
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('<html');
+    expect(html).toContain('</html>');
+  });
+
+  it('contains an SVG flower', () => {
+    const html = generateFlowerTileHTML(TEST_DID);
+    expect(html).toContain('<svg');
+    expect(html).toContain('</svg>');
+  });
+
+  it('includes a link to the user garden', () => {
+    const html = generateFlowerTileHTML(TEST_DID);
+    expect(html).toContain(`spores.garden/${encodeURIComponent(TEST_DID)}`);
+  });
+
+  it('is deterministic — same DID produces identical output', () => {
+    const a = generateFlowerTileHTML(TEST_DID);
+    const b = generateFlowerTileHTML(TEST_DID);
+    expect(a).toBe(b);
+  });
+
+  it('produces different output for different DIDs', () => {
+    const a = generateFlowerTileHTML('did:plc:aaaaaaaaaaaaaaaa');
+    const b = generateFlowerTileHTML('did:plc:bbbbbbbbbbbbbbbb');
+    expect(a).not.toBe(b);
+  });
+
+  it('bakes background color from theme into the CSS', () => {
+    const html = generateFlowerTileHTML(TEST_DID);
+    expect(html).toMatch(/background:\s*#[0-9a-fA-F]{6}/);
+  });
+
+  it('is self-contained with no external script or stylesheet references', () => {
+    const html = generateFlowerTileHTML(TEST_DID);
+    expect(html).not.toMatch(/<script\s+src=/);
+    expect(html).not.toMatch(/<link\s+rel="stylesheet"/);
+  });
+
+  describe('manifest contract', () => {
+    it('produces HTML that can be encoded as a UTF-8 Blob without loss', () => {
+      const html = generateFlowerTileHTML(TEST_DID);
+      const encoded = new TextEncoder().encode(html);
+      const decoded = new TextDecoder().decode(encoded);
+      expect(decoded).toBe(html);
+    });
+
+    it('does not contain bare </script> tags that would break srcdoc embedding', () => {
+      const html = generateFlowerTileHTML(TEST_DID);
+      // An unescaped </script> inside srcdoc terminates the parent document's script
+      // block early. The tile has no inline scripts, so this should never appear.
+      expect(html).not.toContain('</script>');
+    });
+
+    it('does not embed the DID in a way that could break HTML attribute context', () => {
+      // DID characters are alphanumeric + colon, safe in attribute values,
+      // but verify no angle brackets or quotes slip through from future changes.
+      const did = 'did:plc:abc123testdid';
+      const html = generateFlowerTileHTML(did);
+      const gardenLinkMatch = html.match(/href="([^"]+)"/g) || [];
+      for (const attr of gardenLinkMatch) {
+        expect(attr).not.toContain('<');
+        expect(attr).not.toContain('>');
+      }
+    });
+  });
+});

--- a/src/tiles/flower-tile.ts
+++ b/src/tiles/flower-tile.ts
@@ -1,0 +1,52 @@
+/**
+ * Generates a self-contained HTML tile that renders a user's unique flower.
+ * The flower SVG and theme colors are baked into the HTML at publish time.
+ */
+
+import { generateFlowerSVGString } from '../utils/flower-svg';
+import { generateThemeFromDid } from '../themes/engine';
+
+export function generateFlowerTileHTML(did: string): string {
+  const flowerSVG = generateFlowerSVGString(did, 200);
+  const { theme } = generateThemeFromDid(did);
+  const { colors } = theme;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>flower</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html, body {
+  width: 100%; height: 100%; overflow: hidden;
+  background: ${colors.background};
+  color: ${colors.text};
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+}
+.tile {
+  width: 100%; height: 100%;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 12px;
+}
+.flower svg { display: block; }
+.brand {
+  font-size: 13px; font-weight: 500;
+  opacity: 0.6; letter-spacing: -0.2px;
+}
+.brand a {
+  color: ${colors.primary};
+  text-decoration: none;
+}
+</style>
+</head>
+<body>
+<div class="tile">
+  <div class="flower">${flowerSVG}</div>
+  <div class="brand"><a href="https://spores.garden/${encodeURIComponent(did)}" target="_blank" rel="noopener">spores.garden</a></div>
+</div>
+</body>
+</html>`;
+}

--- a/src/tiles/tile-publisher.ts
+++ b/src/tiles/tile-publisher.ts
@@ -1,0 +1,35 @@
+/**
+ * Publishes a flower web tile to the user's PDS as an ing.dasl.masl record.
+ */
+
+import { uploadBlob, createRecord } from '../oauth';
+import { generateFlowerTileHTML } from './flower-tile';
+
+const TILE_COLLECTION = 'ing.dasl.masl';
+
+export async function publishFlowerTile(did: string): Promise<{ uri: string; cid: string }> {
+  const html = generateFlowerTileHTML(did);
+  const blob = new Blob([html], { type: 'text/html' });
+
+  const upload = await uploadBlob(blob, 'application/octet-stream');
+  const blobRef = upload.data?.blob;
+  if (!blobRef) {
+    throw new Error('Failed to upload tile blob');
+  }
+
+  const record = {
+    name: 'My Flower',
+    description: 'A unique flower generated from my DID on spores.garden',
+    sizing: { width: 300, height: 300 },
+    resources: {
+      '/': {
+        src: blobRef,
+        'content-type': 'text/html'
+      }
+    },
+    createdAt: new Date().toISOString()
+  };
+
+  const result = await createRecord(TILE_COLLECTION, record);
+  return { uri: result.uri, cid: result.cid };
+}

--- a/src/tiles/tile-publisher.ts
+++ b/src/tiles/tile-publisher.ts
@@ -11,25 +11,47 @@ export async function publishFlowerTile(did: string): Promise<{ uri: string; cid
   const html = generateFlowerTileHTML(did);
   const blob = new Blob([html], { type: 'text/html' });
 
-  const upload = await uploadBlob(blob, 'application/octet-stream');
+  const uploadMimeType = 'application/octet-stream';
+  console.log('[publishFlowerTile] uploading tile blob', {
+    did,
+    htmlLength: html.length,
+    blobSize: blob.size,
+    blobType: blob.type,
+    uploadMimeType
+  });
+
+  const upload = await uploadBlob(blob, uploadMimeType);
   const blobRef = upload.data?.blob;
+  console.log('[publishFlowerTile] upload result', {
+    hasBlobRef: !!blobRef,
+    blobRef
+  });
   if (!blobRef) {
     throw new Error('Failed to upload tile blob');
   }
 
   const record = {
-    name: 'My Flower',
-    description: 'A unique flower generated from my DID on spores.garden',
-    sizing: { width: 300, height: 300 },
-    resources: {
-      '/': {
-        src: blobRef,
-        'content-type': 'text/html'
+    $type: TILE_COLLECTION,
+    tile: {
+      name: 'My Flower',
+      description: 'A unique flower generated from my DID on spores.garden',
+      sizing: { width: 300, height: 300 },
+      resources: {
+        '/': {
+          src: blobRef,
+          'content-type': 'text/html; charset=utf-8'
+        }
       }
     },
     createdAt: new Date().toISOString()
   };
 
+  console.log('[publishFlowerTile] creating record', {
+    collection: TILE_COLLECTION,
+    record
+  });
+
   const result = await createRecord(TILE_COLLECTION, record);
+  console.log('[publishFlowerTile] record created', result);
   return { uri: result.uri, cid: result.cid };
 }

--- a/src/tiles/tile-publisher.ts
+++ b/src/tiles/tile-publisher.ts
@@ -2,6 +2,8 @@
  * Publishes a flower web tile to the user's PDS as an ing.dasl.masl record.
  */
 
+import { encode } from '@atcute/cbor';
+import * as CID from '@atcute/cid';
 import { uploadBlob, createRecord } from '../oauth';
 import { generateFlowerTileHTML } from './flower-tile';
 
@@ -30,19 +32,23 @@ export async function publishFlowerTile(did: string): Promise<{ uri: string; cid
     throw new Error('Failed to upload tile blob');
   }
 
+  const tile = {
+    name: 'My Flower',
+    description: 'A unique flower generated from my DID on spores.garden',
+    sizing: { width: 300, height: 300 },
+    resources: {
+      '/': {
+        src: blobRef,
+        'content-type': 'text/html; charset=utf-8'
+      }
+    }
+  };
+
+  const maslCid = CID.toString(await CID.create(0x71, encode(tile)));
   const record = {
     $type: TILE_COLLECTION,
-    tile: {
-      name: 'My Flower',
-      description: 'A unique flower generated from my DID on spores.garden',
-      sizing: { width: 300, height: 300 },
-      resources: {
-        '/': {
-          src: blobRef,
-          'content-type': 'text/html; charset=utf-8'
-        }
-      }
-    },
+    cid: maslCid,
+    tile,
     createdAt: new Date().toISOString()
   };
 


### PR DESCRIPTION
## Summary

- Adds a new `web-tile` section type that publishes the user's unique DID-derived flower as a self-contained `ing.dasl.masl` record on their PDS
- Generates static HTML with the flower SVG and theme colors baked in at publish time — no runtime dependencies
- Renders the tile via `iframe.srcdoc` (fetched blob content) to avoid browser MIME-type issues with PDS blob serving
- Validates that the referenced record is an `ing.dasl.masl` collection with a `text/html` root resource before rendering

## New files

- `src/tiles/flower-tile.ts` — `generateFlowerTileHTML(did)` produces self-contained HTML
- `src/tiles/tile-publisher.ts` — uploads blob + creates `ing.dasl.masl` record on PDS
- `src/tiles/flower-tile.test.ts` — 10 unit tests covering structure, determinism, and srcdoc safety

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (165 tests)
- [x] In edit mode: Add Section → Flower Tile → confirms tile publishes and renders in garden
- [x] Verify `ing.dasl.masl` record appears on PDS via pdsls.dev