### PR TITLE
Fix production OAuth client metadata scope

### DIFF
--- a/public/client-metadata.json
+++ b/public/client-metadata.json
@@ -5,7 +5,7 @@
     "redirect_uris": [
         "https://spores.garden/"
     ],
-    "scope": "atproto transition:generic",
+    "scope": "atproto blob:*/* repo:app.bsky.feed.post?action=create repo:coop.hypha.spores.content.image repo:coop.hypha.spores.content.text repo:coop.hypha.spores.item.specialSpore repo:coop.hypha.spores.site.config repo:coop.hypha.spores.site.layout repo:coop.hypha.spores.site.profile repo:coop.hypha.spores.site.section repo:coop.hypha.spores.social.flower repo:coop.hypha.spores.social.takenFlower repo:garden.spores.content.image repo:garden.spores.content.text repo:garden.spores.item.specialSpore repo:garden.spores.site.config repo:garden.spores.site.layout repo:garden.spores.site.profile repo:garden.spores.site.sections repo:garden.spores.site.section repo:garden.spores.social.flower repo:garden.spores.social.takenFlower",
     "grant_types": [
         "authorization_code",
         "refresh_token"


### PR DESCRIPTION
## Summary
Fix the live OAuth invalid_scope login failure by updating the production client metadata served from public/client-metadata.json.

## Root Cause
The granular OAuth scope change was already merged in application code, but GitHub Pages serves client-metadata.json from the public/ directory. That production metadata file still declared the old transitional scope, so Bluesky rejected blob:*/* as undeclared.

## Changes
- update public/client-metadata.json to the granular scope list used by the app

## Validation
- npm run build
- npm run typecheck:strict
- verified dist/client-metadata.json contains blob:*/* and the full granular scope list
